### PR TITLE
HOTFIX: using href instead of onclick for mobile

### DIFF
--- a/src/frontend/html/table.html
+++ b/src/frontend/html/table.html
@@ -128,17 +128,20 @@
   </p>
 
 
-<div onclick="window.open('{{.UrlCity1}}', '_blank');" class="clickable">
+<!-- Link for Flights From -->
+<a href="{{.UrlCity1}}" target="_blank" class="clickable">
   <p>
     Flights From: {{if and .PriceCity1.Valid (ne .PriceCity1.Float64 0.00)}}€{{printf "%.2f" .PriceCity1.Float64}}{{else}}N/A{{end}}
   </p>
-</div>
+</a>
 
-<div onclick="window.open('{{.BookingUrl}}', '_blank');" class="clickable">
+<!-- Link for Avg. Hotel Price -->
+<a href="{{.BookingUrl}}" target="_blank" class="clickable">
   <p>
     Avg. Hotel Price: {{if and .BookingPppn.Valid (ne .BookingPppn.Float64 0.00)}}€{{printf "%.2f" .BookingPppn.Float64}}{{else}}N/A{{end}}
   </p>
-</div>
+</a>
+
 
     </div>
   </div>


### PR DESCRIPTION
for some reason fairfarefinder.com/{ was being prepended to booking urls in mobile view