### PR TITLE
FIX: Save logging in chunks

### DIFF
--- a/utils/data/process/compile/main/main.go
+++ b/utils/data/process/compile/main/main.go
@@ -286,7 +286,7 @@ func main() {
 			transfer := false
 
 			// Generate new db every 6 hours: 3 = 3am; 9am; 3pm; 9pm.
-			if currentHour%6 == 1 {
+			if currentHour%6 == 3 {
 
 				// Monday, 3am, Start a completely new new_main.db
 				if currentDay == time.Monday && currentHour == 3 {


### PR DESCRIPTION
I suspect FD File Descriptor limits are causing issues with our logging of crashes, This fix stores logging data as chunks